### PR TITLE
Add systemd integration for automated GitHub bot execution

### DIFF
--- a/github-activity-bot.service
+++ b/github-activity-bot.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=GitHub Activity Bot Service
+After=network.target
+
+[Service]
+Type=oneshot
+User=your_username
+WorkingDirectory=/home/your_username/apps/auto-activity
+Environment=GITHUB_TOKEN=your_github_token_here
+Environment=GITHUB_USERNAME=your_github_username
+Environment=GITHUB_REPO=your_repo_name
+ExecStart=/home/your_username/apps/auto-activity/venv/bin/python /home/your_username/apps/auto-activity/github-activity-bot.py
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/github-activity-bot.timer
+++ b/github-activity-bot.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run GitHub Activity Bot daily
+Requires=github-activity-bot.service
+
+[Timer]
+OnCalendar=daily
+RandomizedDelaySec=300
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/github-auto-pr.service
+++ b/github-auto-pr.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=GitHub Auto PR Bot Service
+After=network.target
+
+[Service]
+Type=oneshot
+User=your_username
+WorkingDirectory=/home/your_username/apps/auto-activity
+Environment=GITHUB_TOKEN=your_github_token_here
+Environment=GITHUB_USERNAME=your_github_username
+Environment=GITHUB_REPO=your_repo_name
+ExecStart=/home/your_username/apps/auto-activity/venv/bin/python /home/your_username/apps/auto-activity/github-auto-pr.py
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/github-auto-pr.timer
+++ b/github-auto-pr.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run GitHub Auto PR Bot weekly
+Requires=github-auto-pr.service
+
+[Timer]
+OnCalendar=weekly
+RandomizedDelaySec=300
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/setup-systemd.sh
+++ b/setup-systemd.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# GitHub Automation Systemd Setup Script
+
+set -e
+
+echo "GitHub Automation Scripts - Systemd Setup"
+echo "=========================================="
+
+# 変数設定
+SERVICE_USER=$(whoami)
+SCRIPT_DIR=$(pwd)
+SERVICE_DIR="/etc/systemd/system"
+
+# 必要な情報を入力させる
+read -p "GitHub Username: " GITHUB_USERNAME
+read -p "GitHub Repository Name: " GITHUB_REPO
+read -s -p "GitHub Token: " GITHUB_TOKEN
+echo
+
+# サービスファイルをコピーして設定を更新
+echo "Setting up service files..."
+
+# Activity Bot Service
+sudo cp github-activity-bot.service ${SERVICE_DIR}/
+sudo sed -i "s|your_username|${SERVICE_USER}|g" ${SERVICE_DIR}/github-activity-bot.service
+sudo sed -i "s|/home/your_username/apps/auto-activity|${SCRIPT_DIR}|g" ${SERVICE_DIR}/github-activity-bot.service
+sudo sed -i "s|your_github_token_here|${GITHUB_TOKEN}|g" ${SERVICE_DIR}/github-activity-bot.service
+sudo sed -i "s|your_github_username|${GITHUB_USERNAME}|g" ${SERVICE_DIR}/github-activity-bot.service
+sudo sed -i "s|your_repo_name|${GITHUB_REPO}|g" ${SERVICE_DIR}/github-activity-bot.service
+
+# Auto PR Service
+sudo cp github-auto-pr.service ${SERVICE_DIR}/
+sudo sed -i "s|your_username|${SERVICE_USER}|g" ${SERVICE_DIR}/github-auto-pr.service
+sudo sed -i "s|/home/your_username/apps/auto-activity|${SCRIPT_DIR}|g" ${SERVICE_DIR}/github-auto-pr.service
+sudo sed -i "s|your_github_token_here|${GITHUB_TOKEN}|g" ${SERVICE_DIR}/github-auto-pr.service
+sudo sed -i "s|your_github_username|${GITHUB_USERNAME}|g" ${SERVICE_DIR}/github-auto-pr.service
+sudo sed -i "s|your_repo_name|${GITHUB_REPO}|g" ${SERVICE_DIR}/github-auto-pr.service
+
+# Timer files
+sudo cp github-activity-bot.timer ${SERVICE_DIR}/
+sudo cp github-auto-pr.timer ${SERVICE_DIR}/
+
+# systemdを再読み込み
+echo "Reloading systemd..."
+sudo systemctl daemon-reload
+
+# サービスを有効化
+echo "Enabling services..."
+sudo systemctl enable github-activity-bot.service
+sudo systemctl enable github-auto-pr.service
+sudo systemctl enable github-activity-bot.timer
+sudo systemctl enable github-auto-pr.timer
+
+# タイマーを開始
+echo "Starting timers..."
+sudo systemctl start github-activity-bot.timer
+sudo systemctl start github-auto-pr.timer
+
+echo ""
+echo "Setup completed successfully!"
+echo ""
+echo "Service status:"
+sudo systemctl status github-activity-bot.timer --no-pager
+sudo systemctl status github-auto-pr.timer --no-pager
+
+echo ""
+echo "Next scheduled runs:"
+sudo systemctl list-timers github-*
+
+echo ""
+echo "Useful commands:"
+echo "  sudo systemctl status github-activity-bot.timer"
+echo "  sudo systemctl status github-auto-pr.timer" 
+echo "  sudo journalctl -u github-activity-bot.service"
+echo "  sudo journalctl -u github-auto-pr.service"
+echo "  sudo systemctl stop github-activity-bot.timer"
+echo "  sudo systemctl stop github-auto-pr.timer"


### PR DESCRIPTION
## 概要
systemdを使用したGitHub Botの自動実行機能を追加しました。

## 変更内容
- **github-activity-bot.service**: Activity Bot用のsystemdサービスファイル
- **github-auto-pr.service**: Auto PR Bot用のsystemdサービスファイル  
- **github-activity-bot.timer**: 毎日実行用のタイマーファイル
- **github-auto-pr.timer**: 毎週実行用のタイマーファイル
- **setup-systemd.sh**: 自動セットアップスクリプト
- **README.md**: systemd設定・管理方法を追加

## 機能
- システムレベルでの自動実行
- 毎日・毎週の定期実行
- ランダム遅延による負荷分散
- journalctlによるログ管理
- システム再起動後の自動復旧

## セットアップ方法
```bash
chmod +x setup-systemd.sh
./setup-systemd.sh
```

PM2よりも安定した自動実行が可能になります。